### PR TITLE
Saving Authentication Credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/build
+*/*.xcodeproj/*.mode1v3
+*/*.xcodeproj/*.pbxuser
+.DS_Store
+*.orig
+*.pbxuser
+*.perspective*
+*.xcworkspace
+*xcuserdata
+*/*.idea/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Example/Vendor/AFNetworking"]
 	path = Example/Vendor/AFNetworking
 	url = git://github.com/AFNetworking/AFNetworking.git
+[submodule "Example/Vendor/UIKeyChainStore"]
+	path = Example/Vendor/UIKeyChainStore
+	url = git://github.com/kishikawakatsumi/UICKeyChainStore.git

--- a/Example/TentStatusExample.xcodeproj/project.pbxproj
+++ b/Example/TentStatusExample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6835E53C24D5C71A51E4DAA5 /* UICKeyChainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 6835E44BB15E7EA0EF875D7D /* UICKeyChainStore.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6835E8330BFA285809387AD7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6835E38390B0F179EBB33DFA /* Security.framework */; };
 		9F24FC86161AAC0100A93048 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F24FC85161AAC0100A93048 /* UIKit.framework */; };
 		9F24FC88161AAC0100A93048 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F24FC87161AAC0100A93048 /* Foundation.framework */; };
 		9F24FC8A161AAC0100A93048 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F24FC89161AAC0100A93048 /* CoreGraphics.framework */; };
@@ -42,6 +44,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6835E38390B0F179EBB33DFA /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		6835E44BB15E7EA0EF875D7D /* UICKeyChainStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UICKeyChainStore.m; path = Vendor/UIKeyChainStore/UICKeyChainStore.m; sourceTree = "<group>"; };
+		6835E54D48C3DC2610453879 /* UICKeyChainStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UICKeyChainStore.h; path = Vendor/UIKeyChainStore/UICKeyChainStore.h; sourceTree = "<group>"; };
 		9F24FC81161AAC0100A93048 /* TentStatusExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TentStatusExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F24FC85161AAC0100A93048 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		9F24FC87161AAC0100A93048 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -111,12 +116,22 @@
 				9F24FC86161AAC0100A93048 /* UIKit.framework in Frameworks */,
 				9F24FC88161AAC0100A93048 /* Foundation.framework in Frameworks */,
 				9F24FC8A161AAC0100A93048 /* CoreGraphics.framework in Frameworks */,
+				6835E8330BFA285809387AD7 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6835E0D8F2F3C53868C1F412 /* UIKeyChainStore */ = {
+			isa = PBXGroup;
+			children = (
+				6835E44BB15E7EA0EF875D7D /* UICKeyChainStore.m */,
+				6835E54D48C3DC2610453879 /* UICKeyChainStore.h */,
+			);
+			name = UIKeyChainStore;
+			sourceTree = "<group>";
+		};
 		9F24FC76161AAC0100A93048 = {
 			isa = PBXGroup;
 			children = (
@@ -138,6 +153,7 @@
 		9F24FC84161AAC0100A93048 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6835E38390B0F179EBB33DFA /* Security.framework */,
 				9F24FC85161AAC0100A93048 /* UIKit.framework */,
 				9F24FC87161AAC0100A93048 /* Foundation.framework */,
 				9F24FC89161AAC0100A93048 /* CoreGraphics.framework */,
@@ -180,6 +196,7 @@
 				9F24FCB2161AB09500A93048 /* TPTentClient */,
 				9F24FED7161AB0C500A93048 /* AFNetworking */,
 				9F24FE3C161AB0BE00A93048 /* SSToolkit */,
+				6835E0D8F2F3C53868C1F412 /* UIKeyChainStore */,
 			);
 			name = Vendor;
 			sourceTree = "<group>";
@@ -378,6 +395,7 @@
 				9F83DF20161BC0AC0078F22C /* AccountViewController.m in Sources */,
 				9F859A84161BD4D300CE3388 /* NSURL+TPEquivalence.m in Sources */,
 				9F859A8C161D0C0700CE3388 /* NewStatusPostViewController.m in Sources */,
+				6835E53C24D5C71A51E4DAA5 /* UICKeyChainStore.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TPTentClient/TPTentClient.m
+++ b/TPTentClient/TPTentClient.m
@@ -78,11 +78,22 @@ static NSString * const TPTentClientProfileInfoTypeBasic = @"https://tent.io/typ
     [self headTentServerWithDiscoveryHTTPClient:discoveryHTTPClient success:success failure:failure];
 }
 
+
 #pragma mark OAuth
+
+- (void)initHttpClient:(NSURL *)url
+{
+    if (![self.httpClient.baseURL isEquivalent:url]) {
+        self.httpClient = [[TPTentHTTPClient alloc] initWithBaseURL:url];
+        self.httpClient.delegate = self;
+    }
+}
 
 - (BOOL)isAuthorizedForTentServer:(NSURL *)url
 {
-    if (self.httpClient && [self.httpClient.baseURL isEquivalent:url] && [self.httpClient isRegisteredWithBaseURL]) {
+    [self initHttpClient:url];
+
+    if ([self.httpClient isRegisteredWithBaseURL]) {
         return YES;
     }
     
@@ -101,12 +112,9 @@ static NSString * const TPTentClientProfileInfoTypeBasic = @"https://tent.io/typ
     if (self.httpClient.isRegisteredWithBaseURL && [self.httpClient.baseURL isEqual:url]) {
         return;
     }
-    
-    if (![self.httpClient.baseURL isEqual:url]) {
-        self.httpClient = [[TPTentHTTPClient alloc] initWithBaseURL:url];
-        self.httpClient.delegate = self;
-    }
-    
+
+    [self initHttpClient:url];
+
     [[NSNotificationCenter defaultCenter] postNotificationName:TPTentClientWillAuthorizeWithTentServerNotification
                                                         object:nil
                                                       userInfo:@{TPTentClientAuthorizingWithTentServerURLKey: url}];

--- a/TPTentClient/TPTentHTTPClient.h
+++ b/TPTentClient/TPTentHTTPClient.h
@@ -25,6 +25,14 @@
 
 @protocol TPTentHTTPDelegate;
 
+static NSString *const BASE_URL = @"base_url";
+static NSString *const ENTITY = @"entity";
+static NSString *const ACCESS_TOKEN = @"access_token";
+static NSString *const MAC_KEY = @"mac_key";
+static NSString *const MAC_ALGORITHM = @"mac_algorithm";
+static NSString *const MAC_KEY_ID = @"mac_key_id";
+static NSString *const CLIENT_ID = @"client_id";
+
 @interface TPTentHTTPClient : AFHTTPClient
 
 @property (nonatomic, weak) id<TPTentHTTPDelegate> delegate;


### PR DESCRIPTION
This introduces saving the Authentication Credentials in iOS's Keychain.

It uses a submodule which simplifies the Keychain access tremendously: _UICKeyChainStore_. Unfortunately, it's not ARC compatible so I had to add the flag `-fno-objc-arc` to the two source files. 

The credentials are stored once the authorization succeeded and used as soon as an `TPTentHTTPClient`instance is created with the same URL. 

Unfortunately, I had to change `AccountViewController` a little bit to adjust the flow. 

_Note: there is no error handling or logging out! You'd basically have to login with a different entity in order to overwrite the Keychain entries!_
