### PR TITLE
Fixed increasing the cell height everytime you reload

### DIFF
--- a/Example/TentStatusExample/TimelineViewController.m
+++ b/Example/TentStatusExample/TimelineViewController.m
@@ -92,15 +92,13 @@
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    // TODO: Fix this
-    StatusPostCell *cell = [tableView dequeueReusableCellWithIdentifier:@"StatusPostCell"];
-    StatusPost *statusPost = (StatusPost *)[self.statusArray objectAtIndex:indexPath.row];
-    cell.statusLabel.text = statusPost.status;
-    CGFloat cellHeight = cell.frame.size.height;
-    CGFloat labelHeight = 19.f;
-    CGFloat adjustedlabelHeight = [cell.statusLabel sizeThatFits:CGSizeMake(280.f, CGFLOAT_MAX)].height;
-    CGFloat adjustedCellHeight = cellHeight + (adjustedlabelHeight - labelHeight);
-    return adjustedCellHeight;
+
+    NSString *cellText = ((StatusPost *)[self.statusArray objectAtIndex:indexPath.row]).status;
+    UIFont *cellFont = [UIFont fontWithName:@"Helvetica Neue" size:14.0f];
+    CGSize constraintSize = CGSizeMake(280.0f, MAXFLOAT);
+    CGSize labelSize = [cellText sizeWithFont:cellFont constrainedToSize:constraintSize lineBreakMode:NSLineBreakByTruncatingTail];
+
+    return labelSize.height + 86.0f;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section


### PR DESCRIPTION
Changed calculation of cell height. It's not based on the current cell anymore, but only the content. This prevents the cell to increase size each time it's redrawn.

_Note: haven't merged this into the other branches yet, I though you might want to do that yourself_
